### PR TITLE
Add a link to the README with the original repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A repository to promote open source developers and organizations in Sault Ste. Marie, Ontario.
 
+Project Home: https://github.com/cityssm/sault-ste-marie-coders
 
 ## Organizations
 


### PR DESCRIPTION
With many clones floating around I think it makes sense to highlight
where "home" is (where we should check back for the latest list).